### PR TITLE
[RFR] have SelectByOrderedIdentifiers work with primaryKey array too

### DIFF
--- a/packages/builder/src/queries/select/Select.ts
+++ b/packages/builder/src/queries/select/Select.ts
@@ -36,7 +36,7 @@ export const select = ({
     returnOne,
 }: Select): QueryFunction => {
     const primaryKey = [].concat(ids);
-    const select = returnCols.length ? returnCols.join(', ') : '*';
+    const selectedCol = returnCols.length ? returnCols.join(', ') : '*';
 
     return (
         { limit, offset, filters = {}, sort, sortDir } = { filters: {} },
@@ -52,7 +52,7 @@ export const select = ({
 
         const where = whereQuery(finalFilters, finalSearchableCols);
 
-        let sql = `SELECT ${select} FROM ${table} ${where}`;
+        let sql = `SELECT ${selectedCol} FROM ${table} ${where}`;
 
         if (groupByCols.length > 0) {
             sql = `${sql} GROUP BY ${groupByCols.join(', ')}`;

--- a/packages/builder/src/queries/select/SelectByOrderedIdentifiers.spec.ts
+++ b/packages/builder/src/queries/select/SelectByOrderedIdentifiers.spec.ts
@@ -22,4 +22,26 @@ ON table.id::varchar=x.id
 ORDER BY x.ordering;`,
         });
     });
+
+    it('should work with array of primaryKey by using first key as identifier', () => {
+        const selectQuery = selectByOrderedIdentifiers({
+            primaryKey: ['id', 'uid'],
+            returnCols: ['cola', 'colb'],
+            table: 'table',
+        });
+
+        expect(selectQuery([1, 2])).toEqual({
+            parameters: {
+                id1: 1,
+                id2: 2,
+            },
+            sql: `SELECT table.cola, table.colb
+FROM table
+JOIN (
+VALUES ($id1, 1), ($id2, 2)
+) AS x (id, ordering)
+ON table.id::varchar=x.id
+ORDER BY x.ordering;`,
+        });
+    });
 });

--- a/packages/builder/src/queries/select/SelectByOrderedIdentifiers.ts
+++ b/packages/builder/src/queries/select/SelectByOrderedIdentifiers.ts
@@ -14,6 +14,9 @@ export const selectByOrderedIdentifiers = ({
     primaryKey,
     returnCols = ['*'],
 }: SelectByOrderedIdentifiers): QueryFunction => values => {
+    const identifierName = Array.isArray(primaryKey)
+        ? primaryKey[0]
+        : primaryKey;
     if (!Array.isArray(values)) {
         throw new Error(
             'selectByOrderedIdentifiers values parameter should be an array',
@@ -26,15 +29,15 @@ export const selectByOrderedIdentifiers = ({
 FROM ${table}
 JOIN (
 VALUES ${values
-        .map((row, index) => `($${primaryKey}${index + 1}, ${index + 1})`)
+        .map((row, index) => `($${identifierName}${index + 1}, ${index + 1})`)
         .join(', ')}
-) AS x (${primaryKey}, ordering)
-ON ${table}.${primaryKey}::varchar=x.${primaryKey}
+) AS x (${identifierName}, ordering)
+ON ${table}.${identifierName}::varchar=x.${identifierName}
 ORDER BY x.ordering;`;
 
     const parameters = flatten(
-        sanitizeParameter([primaryKey], {
-            [Array.isArray(primaryKey) ? primaryKey[0] : primaryKey]: values,
+        sanitizeParameter([identifierName], {
+            [identifierName]: values,
         }),
     );
 


### PR DESCRIPTION
fix #15 
I did not see any waring from typescript, but I changed SelectByOrderedIdentifiers to work with array as primaryKey