### PR TITLE
[RFR] Expose namedQuery

### DIFF
--- a/docs/pool.md
+++ b/docs/pool.md
@@ -33,8 +33,6 @@ import { namedQueryFromPoolClient } from 'postgres-queries/pool';
 const pool = new Pool();
 pool.connect().then(client => {
     const namedQuery = namedQueryFromPoolClient(client);
-
-    //
 });
 ```
 

--- a/docs/pool.md
+++ b/docs/pool.md
@@ -25,6 +25,17 @@ const poolingOptions = {
     idleTimeoutMillis // how long a client is allowed to remain idle before being closed (defaults to 30 000 ms)
 }
 const pool = new Pool(clientOptions, poolingOptions);
+
+// Or, you can get a namedQuery directly from another pool client without decorating it:
+import Pool from 'pg-pool';
+import { namedQueryFromPoolClient } from 'postgres-queries/pool';
+
+const pool = new Pool();
+pool.connect().then(client => {
+    const namedQuery = namedQueryFromPoolClient(client);
+
+    //
+});
 ```
 
 ### Getting client with promise

--- a/packages/pool/src/index.ts
+++ b/packages/pool/src/index.ts
@@ -2,43 +2,12 @@ import * as pg from 'pg';
 import * as signale from 'signale';
 import { namedToNumericParameter } from './helpers';
 
-interface QueryData {
-    sql: string;
-    parameters: object;
-    returnOne: boolean;
-}
+import namedQueryFromPoolClient from './namedQuery';
 
-type QueryWithNamedParameters = (queryData: QueryData) => Promise<any[] | null>;
+export { namedQueryFromPoolClient };
 
 function setupClient(client: pg.PoolClient) {
-    const namedQuery: QueryWithNamedParameters = async queryData => {
-        if (queryData.sql === null) {
-            throw new Error('sql cannot be null');
-        }
-
-        if (queryData.sql === '') {
-            return queryData.returnOne ? null : [];
-        }
-
-        const {
-            sql: parsedSql,
-            parameters: parsedParameters,
-        } = namedToNumericParameter(queryData.sql, queryData.parameters);
-
-        const result = await client
-            .query(parsedSql, parsedParameters)
-            .then(queryResult => queryResult.rows);
-
-        if (queryData.returnOne && result.length > 1) {
-            signale.warn(
-                `Query supposed to return only one result but got ${
-                    result.length
-                }`,
-            );
-        }
-
-        return queryData.returnOne ? result[0] : result;
-    };
+    const namedQuery = namedQueryFromPoolClient(client);
 
     const linkOne = (querier: any) => (args: Iterable<object>) =>
         namedQuery(querier(...args));

--- a/packages/pool/src/namedQuery.ts
+++ b/packages/pool/src/namedQuery.ts
@@ -1,0 +1,47 @@
+import { PoolClient } from 'pg';
+import * as signale from 'signale';
+
+import { namedToNumericParameter } from './helpers';
+
+export interface QueryData {
+    sql: string;
+    parameters: object;
+    returnOne: boolean;
+}
+
+type QueryWithNamedParameters = (queryData: QueryData) => Promise<any[] | null>;
+
+const namedQueryFactory = (client: PoolClient) => {
+    const namedQuery: QueryWithNamedParameters = async queryData => {
+        if (queryData.sql === null) {
+            throw new Error('sql cannot be null');
+        }
+
+        if (queryData.sql === '') {
+            return queryData.returnOne ? null : [];
+        }
+
+        const {
+            sql: parsedSql,
+            parameters: parsedParameters,
+        } = namedToNumericParameter(queryData.sql, queryData.parameters);
+
+        const result = await client
+            .query(parsedSql, parsedParameters)
+            .then(queryResult => queryResult.rows);
+
+        if (queryData.returnOne && result.length > 1) {
+            signale.warn(
+                `Query supposed to return only one result but got ${
+                    result.length
+                }`,
+            );
+        }
+
+        return queryData.returnOne ? result[0] : result;
+    };
+
+    return namedQuery;
+};
+
+export default namedQueryFactory;


### PR DESCRIPTION
Expose the namedQuery without having to create a PG pool.

This will be extremly useful to migrate from co-postgres-queries.